### PR TITLE
Remove loading of unused css file

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -17,7 +17,7 @@ class FieldServiceProvider extends ServiceProvider
     {
         Nova::serving(function (ServingNova $event) {
             Nova::script('badge', __DIR__.'/../dist/js/field.js');
-            Nova::style('badge', __DIR__.'/../dist/css/field.css');
+            //Nova::style('badge', __DIR__.'/../dist/css/field.css');
         });
     }
 


### PR DESCRIPTION
Hi,

I left the stubs for generating of the fields css file. Just commented it out so nova dosent request the empty css file.